### PR TITLE
Create object with Object.create(null)

### DIFF
--- a/lib/esq.js
+++ b/lib/esq.js
@@ -3,7 +3,7 @@
   var previous_ESQ = root.ESQ;
 
   var ESQ = function() {
-    this._query = { };
+    this._query = Object.create(null);
   };
 
   ESQ.prototype.getQuery = function() {
@@ -25,9 +25,9 @@
       if(names[i] instanceof Array) {
         names[i] = names[i][0];
         base[names[i]] = base[names[i]] || [];
-        base = base[names[i]][base[names[i]].length] = {};
+        base = base[names[i]][base[names[i]].length] = Object.create(null);
       } else {
-        base = base[names[i]] = base[names[i]] || { };
+        base = base[names[i]] = base[names[i]] || Object.create(null);
       }
     }
 
@@ -39,7 +39,7 @@
       } else if (value instanceof Object) {
         base[lastName] ? this._extend(base[lastName], value) : base[lastName] = value;
       }
-      base = base[lastName] = ((typeof base[lastName] === "object") ? base[lastName] : undefined) || value || { };
+      base = base[lastName] = ((typeof base[lastName] === "object") ? base[lastName] : undefined) || value || Object.create(null);
     }
 
     if ((names.length == 0) && !lastName && value) {


### PR DESCRIPTION
In my use-case, I use a lib which modify Object.prototype, so I need to create my object with Object.create(null) to avoid problem when I generate my query.

This lib is Should.js which create Object.prototype.should and I can't use a should property in my query :(
