### PR TITLE
Add fluent interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,21 +134,34 @@ __Generates__
 
 #### Fluent Interface
 #### esq.q(str, ..., str, value);
-Operates as `esq.query()`, but returns `this` so that query builders can be chained.
+Operates as `esq.query()`, but returns `this` so that `.q()` can be chained fluently.
 Call `.getQuery()` at the end of the chain to get the final result.
 __Example__
 ```javascript
-esq.q('filtered', 'query', { match: { foo: 'bar' } }).getQuery();
+esq.q('query', 'bool', ['must'], { match: { foo: 'bar' } })
+.q('query', 'bool', ['should'], { match: { baz: 'quux' } })
+.getQuery();
 ```
 
 __Generates__
 ```json
 {
-  "filtered": {
-    "query": {
-      "match": {
-        "foo": "bar"
-      }
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "match": {
+            "foo": "bar"
+          }
+        }
+      ],
+      "should": [
+        {
+          "match": {
+            "baz": "quux"
+          }
+        }
+      ]
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ __Generates__
 #### esq.q(str, ..., str, value);
 Operates as `esq.query()`, but returns `this` so that `.q()` can be chained fluently.
 Call `.getQuery()` at the end of the chain to get the final result.
+
 __Example__
 ```javascript
 esq.q('query', 'bool', ['must'], { match: { foo: 'bar' } })

--- a/README.md
+++ b/README.md
@@ -132,6 +132,28 @@ __Generates__
 }
 ```
 
+#### Fluent Interface
+#### esq.q(str, ..., str, value);
+Operates as `esq.query()`, but returns `this` so that query builders can be chained.
+Call `.getQuery()` at the end of the chain to get the final result.
+__Example__
+```javascript
+esq.q('filtered', 'query', { match: { foo: 'bar' } }).getQuery();
+```
+
+__Generates__
+```json
+{
+  "filtered": {
+    "query": {
+      "match": {
+        "foo": "bar"
+      }
+    }
+  }
+}
+```
+
 ---
 
 ## Tests

--- a/esq.js
+++ b/esq.js
@@ -10,12 +10,19 @@
     return this._query;
   };
 
-  ESQ.prototype.query = function() {
-    var args = this._getArgsAsArray(arguments);
-    var value = args.pop();
+  ESQ.prototype._buildQuery = function(argArray) {
+    var value = argArray.pop();
+    this._createNestedObject(this._query, argArray, value);
+  };
 
-    this._createNestedObject(this._query, args, value);
+  ESQ.prototype.query = function() {
+    this._buildQuery(this._getArgsAsArray(arguments));
     return this._query;
+  };
+
+  ESQ.prototype.q = function() {
+    this._buildQuery(this._getArgsAsArray(arguments));
+    return this;
   };
 
   ESQ.prototype._createNestedObject = function(base, names, value) {

--- a/test/testEsq.js
+++ b/test/testEsq.js
@@ -55,7 +55,45 @@ describe('Testing ESQ', function() {
       var result = esq.query('foo', false);
       assert.deepEqual(result, { foo: false });
     });
+  });
 
+  describe('q', function() {
+    it('with no args', function() {
+      var result = esq.q().getQuery();
+      assert.deepEqual(result, { });
+    });
+
+    it('with standard params', function() {
+      var result = esq.q('foo', 'bar', { }).getQuery();
+      assert.deepEqual(result, { foo: { bar: { } } });
+    });
+
+    it('with bad args', function() {
+      var result = esq.q('foo', 'bar', ['foobar'], 123).getQuery();
+      assert.deepEqual(result, { foo: { bar: { foobar: [ 123 ] } } });
+    });
+
+    it('with overwritted string', function() {
+      esq.q('foo', 'bar');
+      var result = esq.q('foo', 'bar2').getQuery();
+      assert.deepEqual(result, { foo: 'bar2' });
+    });
+
+    it('with overwritted number', function() {
+      esq.q('foo', 1);
+      var result = esq.q('foo', 42).getQuery();
+      assert.deepEqual(result, { foo: 42 });
+    });
+
+    it('with zero value', function() {
+      var result = esq.q('foo', 0).getQuery();
+      assert.deepEqual(result, { foo: 0 });
+    });
+
+    it('with false value', function() {
+      var result = esq.q('foo', false).getQuery();
+      assert.deepEqual(result, { foo: false });
+    });
   });
 
   describe('_createNestedObject', function() {


### PR DESCRIPTION
A fluent interface makes building big queries more readable. This is a quick hack to add a fluent interface as a new `.q()` method.
